### PR TITLE
Introduce Transaction::UseCases::Create

### DIFF
--- a/cycad.gemspec
+++ b/cycad.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard'
   spec.add_development_dependency 'guard-rspec'
   spec.add_dependency 'dry-validation'
+  spec.add_dependency 'dry-transaction'
   spec.add_dependency 'sqlite3'
   spec.add_dependency 'rom'
   spec.add_dependency 'rom-sql'

--- a/lib/cycad.rb
+++ b/lib/cycad.rb
@@ -58,7 +58,7 @@ Cycad::Repository.register(:transaction, Database::TransactionRepo.new(Database:
 module Cycad
   class << self
     def create_transaction(args = {})
-      Cycad::Transaction::Interactor.create(args)
+      Cycad::Transaction::UseCases::Create.new.call(args)
     end
 
     def remove_transaction(id)

--- a/lib/cycad/transaction/transaction_interactor.rb
+++ b/lib/cycad/transaction/transaction_interactor.rb
@@ -1,13 +1,12 @@
+require 'cycad/transaction/use_cases/create'
+
 module Cycad
   class Transaction
     class Interactor
       EditResult = Struct.new(:transaction, :errors)
 
-      def self.create(args)
-        validation = Cycad::Transaction::Validator.validate(args)
-        return EditResult.new(nil, validation.errors) if validation.failure?
-        transaction = repo.create(args)
-        EditResult.new(transaction, {})
+      def self.create(input)
+        create_usecase.call(input)
       end
 
       def self.remove(id)
@@ -19,6 +18,10 @@ module Cycad
         return EditResult.new(nil, validation.errors) if validation.failure?
         transaction = repo.update(id, args)
         EditResult.new(transaction, {})
+      end
+
+      def self.create_usecase
+        UseCases::Create.new
       end
 
       private

--- a/lib/cycad/transaction/use_cases/create.rb
+++ b/lib/cycad/transaction/use_cases/create.rb
@@ -1,0 +1,35 @@
+require 'dry/transaction'
+
+module Cycad
+  class Transaction
+    module UseCases
+      class Create
+        include Dry::Transaction
+
+        step :validate
+        step :create
+
+        def validate(input)
+          validation = Cycad::Transaction::Validator.validate(input)
+          if validation.success?
+            Right(input)
+          else
+            Left(validation.errors)
+          end
+        end
+
+        def create(input)
+          transaction = repo.create(input)
+          Right(transaction)
+        end
+
+        private
+
+        def repo
+          Cycad::Repository.for(:transaction)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/transaction/use_cases/create_spec.rb
+++ b/spec/transaction/use_cases/create_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Cycad::Transaction::UseCases::Create do
+  context "validate" do
+    it "is valid when date, amount and category_id are specified" do
+      result = subject.validate({
+        date: Date.parse("2017-12-20"),
+        amount: 20,
+        category_id: "1"
+      })
+
+      expect(result).to be_success
+    end
+
+    it "is invalid when a date is not specified" do
+      result = subject.validate({
+        amount: 20,
+        category_id: "1"
+      })
+
+      expect(result).to be_failure
+      errors = result.value
+      expect(errors[:date]).to include("is missing")
+    end
+  end
+
+  context "persist" do
+    let(:repo) { double }
+
+    before do
+      allow(subject).to receive(:repo) { repo }
+    end
+
+    it "creates the transaction" do
+      input = {
+        date: Date.parse("2017-12-20"),
+        amount: 20,
+        category_id: "1"
+      }
+
+      expect(repo).to receive(:create).with(input) { double }
+      subject.create(input)
+    end
+  end
+end


### PR DESCRIPTION
I was toying around with my [own pet project](https://github.com/radar/surveyor-rom) and came across `dry-transaction`. I liked the idea of separating out the validation + persistence steps into their own separate methods. So I tried doing this in Cycad too.

My initial attempt went something like this:

```
Cycad -> create_transactions -> TransactionInteractor -> UseCases::Create
```

But then I realised that the `TransactionInteractor` _wasn't doing anything_. Well, besides passing parameters through to the usecase. So now it's:

```
Cycad -> create_transactions -> UseCases::Create
```

I really like this approach. Having validation + persistence logic tied up in the one method together felt very ActiveRecord-y to me but I couldn't convey _why_ until I saw how dry-transaction approaches it. Separating these two distinct functions of creating a transaction into their own methods makes the code really neat:

```ruby
require 'dry/transaction'

module Cycad
  class Transaction
    module UseCases
      class Create
        include Dry::Transaction

        step :validate
        step :create

        def validate(input)
          validation = Cycad::Transaction::Validator.validate(input)
          if validation.success?
            Right(input)
          else
            Left(validation.errors)
          end
        end

        def create(input)
          transaction = repo.create(input)
          Right(transaction)
        end

        private

        def repo
          Cycad::Repository.for(:transaction)
        end
      end
    end
  end
end
```

Anything that's to do with validation goes in the `validate` method. For actually creating things in the database, that goes in the `create` method. This way, the `if` statement for handling when a validation succeeds / fails isn't mushed together with persistence in the same method.

If you're not sure what the `Left` / `Right` things are, I think of them like this:

![dry-rb-success-or-fail](https://user-images.githubusercontent.com/2687/34191967-03e7edea-e59f-11e7-8161-6db9d73bb47c.png)

When one of the steps returns a `Left` value, the transaction stops there + then. Think of it like you're ejecting out of the method early; you've "left" the method. "Right" means "everything has been going 'right' so far, so keep going". At least, that's how it works in my head. Shrug.

So there's an argument then for making `UseCases::Update` and `UseCases::Remove` and ditching the interactors altogether. This means then that all the logic for the different actions are then not grouped together in the one interactor, but have separate files which should then have separate tests too.

Imagine an interactor with 5-7 actions you could take and then you wanted to add another method to it. It would be messy (imo). Adding another UseCase::<Action> class though... that seems a little neater.

WDYT?








