### PR TITLE
Add relation :categories to mapper

### DIFF
--- a/lib/cycad/category/category_mapper.rb
+++ b/lib/cycad/category/category_mapper.rb
@@ -3,6 +3,7 @@ require 'cycad/category'
 module Cycad
   class CategoryMapper < ROM::Mapper
     register_as :category
+    relation :categories
 
     model Cycad::Category
 


### PR DESCRIPTION
One goddamned line. Alrighty, here we go.

So after the database config if you put this:

```

require 'pry'
binding.pry
```

And then run `bin/console` it will put you into a pry prompt right before the exception we were seeing. In this prompt, if you run `Database::Config::Rom`, you will see the configured container from this file. This container contains information about your relations, the "gateway" (how ROM connects to the database) aaaaand the mappers!

If you run this code:

```
Database::Config::Rom.mappers
```

You can see this:

```
#<ROM::Registry elements={nil=>#<ROM::MapperRegistry elements={:category=>#<
```

"`nil`? What the hell?" What is it supposed to be if not `nil`?

That lead me on a wild goose chase which led me to this:

https://github.com/rom-rb/rom/blob/131ad48d364a25a75cb01fb37bf0e99458b1073e/core/lib/rom/setup/finalize/finalize_mappers.rb#L15

Looking at `base_relation`:

https://github.com/rom-rb/rom/blob/131ad48d364a25a75cb01fb37bf0e99458b1073e/mapper/lib/rom/mapper/dsl.rb#L49-L55

So it will use the super class's relation if it exists, or otherwise it will call this `relation` method.

Fortunately, I had _just_ removed a `relation` method from my mapper, thinking that it was useless. Adding in this single line to your mapper makes the whole thing work, and the container's mappers now look like:

```
#<ROM::Registry elements={:categories=>#<ROM::MapperRegistry elements={:category=>#...
```

I guess this is so that you can define multiple mappers for the same relation?